### PR TITLE
fix(messaging): release MessageChannel ports on tab close/reload

### DIFF
--- a/utils/messaging/adapters/compositeProvideAdapter.ts
+++ b/utils/messaging/adapters/compositeProvideAdapter.ts
@@ -91,7 +91,7 @@ export class CompositeProvideAdapter implements Adapter<MessageMeta> {
 
     port.onmessageerror = () => {
       logger.withTag('CompositeProvideAdapter').error('Port message error, removing:', secret);
-      this.ports.delete(secret);
+      this.removePort(secret);
     };
 
     // ACK to content script
@@ -128,6 +128,25 @@ export class CompositeProvideAdapter implements Adapter<MessageMeta> {
   }
 
   /**
+   * Close a port and drop it from the map. Closing detaches the handlers and lets the
+   * browser reclaim the MessagePort; deleting the map entry alone leaves it entangled and
+   * started, so a stale port (e.g. from a reloaded tab) can still deliver late messages.
+   */
+  private removePort(secret: string): void {
+    const portInfo = this.ports.get(secret);
+    if (!portInfo) return;
+
+    portInfo.port.onmessage = null;
+    portInfo.port.onmessageerror = null;
+    try {
+      portInfo.port.close();
+    } catch {
+      // Port already closed (e.g. its tab is gone) - nothing to do.
+    }
+    this.ports.delete(secret);
+  }
+
+  /**
    * Associate a channel secret with the tab that owns it. Sent by the content script
    * over browser.runtime (which carries sender.tab.id) once the channel is established.
    * A reload or same-tab navigation produces a fresh secret for the same tab, so any
@@ -141,7 +160,7 @@ export class CompositeProvideAdapter implements Adapter<MessageMeta> {
     portInfo.tabId = tabId;
     for (const [otherSecret, info] of this.ports) {
       if (otherSecret !== secret && info.tabId === tabId) {
-        this.ports.delete(otherSecret);
+        this.removePort(otherSecret);
       }
     }
   }
@@ -153,7 +172,7 @@ export class CompositeProvideAdapter implements Adapter<MessageMeta> {
   private releaseTab = (tabId: number): void => {
     for (const [secret, info] of this.ports) {
       if (info.tabId === tabId) {
-        this.ports.delete(secret);
+        this.removePort(secret);
       }
     }
   };
@@ -196,7 +215,7 @@ export class CompositeProvideAdapter implements Adapter<MessageMeta> {
         }
       } catch {
         // Port is dead - remove it and silently ignore (similar to "Receiving end does not exist")
-        this.ports.delete(secret);
+        this.removePort(secret);
       }
     } else {
       // Route via browser.runtime

--- a/utils/messaging/adapters/compositeProvideAdapter.ts
+++ b/utils/messaging/adapters/compositeProvideAdapter.ts
@@ -12,6 +12,7 @@ interface MessageSender {
 interface PortInfo {
   port: MessagePort;
   secret: string;
+  tabId?: number;
 }
 
 /**
@@ -29,11 +30,18 @@ export class CompositeProvideAdapter implements Adapter<MessageMeta> {
   constructor() {
     this.initializeBrowserRuntime();
     this.initializeMessageChannel();
+    this.initializeTabCleanup();
   }
 
   private initializeBrowserRuntime(): void {
     browser.runtime.onMessage.addListener(
       (message: Partial<Message<MessageMeta>> | undefined, sender: MessageSender) => {
+        const control = message as unknown as { type?: string; secret?: string } | undefined;
+        if (control?.type === 'REGISTER_CHANNEL_TAB') {
+          this.associateTab(control.secret, sender.tab?.id);
+          return;
+        }
+
         const enrichedMessage = message
           ? {
               ...message,
@@ -113,6 +121,42 @@ export class CompositeProvideAdapter implements Adapter<MessageMeta> {
 
     this.messageCallbacks.forEach(callback => callback(enrichedMessage));
   }
+
+  private initializeTabCleanup(): void {
+    browser.tabs.onRemoved.addListener(this.releaseTab);
+    logger.withTag('CompositeProvideAdapter').debug('Tab cleanup listener initialized');
+  }
+
+  /**
+   * Associate a channel secret with the tab that owns it. Sent by the content script
+   * over browser.runtime (which carries sender.tab.id) once the channel is established.
+   * A reload or same-tab navigation produces a fresh secret for the same tab, so any
+   * previous port for that tab is now stale and removed here.
+   */
+  private associateTab(secret: string | undefined, tabId?: number): void {
+    if (!secret || tabId === undefined) return;
+    const portInfo = this.ports.get(secret);
+    if (!portInfo) return;
+
+    portInfo.tabId = tabId;
+    for (const [otherSecret, info] of this.ports) {
+      if (otherSecret !== secret && info.tabId === tabId) {
+        this.ports.delete(otherSecret);
+      }
+    }
+  }
+
+  /**
+   * Drop every port owned by a closed tab. Without this, ports leak for the lifetime
+   * of the service worker since posting to a closed tab's port does not throw.
+   */
+  private releaseTab = (tabId: number): void => {
+    for (const [secret, info] of this.ports) {
+      if (info.tabId === tabId) {
+        this.ports.delete(secret);
+      }
+    }
+  };
 
   sendMessage: SendMessage<MessageMeta> = async (message, transfer) => {
     const meta = message.meta as

--- a/utils/messaging/adapters/messageChannelAdapter.ts
+++ b/utils/messaging/adapters/messageChannelAdapter.ts
@@ -131,6 +131,10 @@ export class MessageChannelInjectAdapter implements Adapter<MessageMeta> {
       throw new Error('Service worker did not ACK MessageChannel');
     }
 
+    // Tell the background which tab owns this channel so it can release the port when the
+    // tab closes or reloads. Runtime messages carry sender.tab.id; the channel itself does not.
+    browser.runtime.sendMessage({ type: 'REGISTER_CHANNEL_TAB', secret }).catch(() => {});
+
     // Wire up message handler for comctx messages
     mc.port1.onmessage = (event: MessageEvent<Partial<Message<MessageMeta>> | undefined>) => {
       // Forward to all registered callbacks


### PR DESCRIPTION
## Summary

Fixes #56 — the background `CompositeProvideAdapter` accumulated stale `MessageChannel` ports for the lifetime of the service worker.

The `ports` map was only pruned reactively (`onmessageerror`, or when `postMessage` threw). Neither fires reliably when a tab **closes or reloads**: posting to a `MessagePort` whose peer is gone silently no-ops rather than throwing. So entries (and the underlying ports) piled up over a long-lived SW session.

## Root cause

Channel routing is keyed by a per-load `secret`, and `tabId` was never plumbed into the channel path (channel replies route back over the same port via the secret, so it was never needed). That left no way to map a closed tab to the ports it owned.

## Fix

- **Associate `secret → tabId`.** The content script sends one fire-and-forget `REGISTER_CHANNEL_TAB` over `browser.runtime` right after the channel is ACKed. Runtime messages carry a browser-injected, trusted `sender.tab.id` — the channel itself does not, and neither side knows the tab id at PORT_READY time.
- **Clean up on the right signals.** `tabs.onRemoved` drops all of a tab's ports; a fresh registration for the same tab evicts the previous (now-stale) port, covering reloads/navigations.
- **Close before dropping.** A deleted-but-still-entangled port stays alive and can deliver late messages to `handlePortMessage`. All removals route through a `removePort` helper that detaches handlers and calls `port.close()` before deleting.

State stays in the single existing `ports` map (one optional `tabId` field on `PortInfo`) — no reverse-lookup maps added.

## Design notes

- **Scope:** unbounded leak → bounded. The only residual is a tab that navigates to a document with no channel and never closes — at most one stale port, reclaimed on tab close.
- **Deliberately not done:** a `tabs.onUpdated` navigation-start sweep. The natural implementation breaks bfcache restores (closes a live port with no re-establishment path → silent loss of filtering), differs across Chrome/Firefox, and adds listener surface. Better as a follow-up paired with a content-side `pageshow` re-init if it ever proves necessary.
- `hybridInjectAdapter` maps (mentioned in the issue) are **not** a background leak — they live in the content-script context and are torn down on tab close / cleared on unsubscribe. No change needed.

## Test plan

- `pnpm compile` ✅
- `pnpm lint` ✅ (only pre-existing `sender.ts` warnings)
- Manual: open/close and reload many tabs over a long SW session; channel connection count returns to baseline instead of growing.

> Unit tests deferred — the repo has no project test suite yet and the adapter needs a DOM env (`happy-dom`/`jsdom`) to exercise PORT_READY. Tracked alongside #54/#55.
