### PR TITLE
chore(ci): bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,15 +15,15 @@ jobs:
       CI: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -36,7 +36,7 @@ jobs:
 
       - name: Upload failure screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: chrome-e2e-screenshots
           path: tests/e2e/screenshots/
@@ -49,15 +49,15 @@ jobs:
       CI: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload failure screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: firefox-e2e-screenshots
           path: tests/e2e/screenshots/
@@ -89,7 +89,7 @@ jobs:
       ANDROID_PAGE_LOAD_STRATEGY: none
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Enable KVM group perms
         run: |
@@ -98,12 +98,12 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -112,7 +112,7 @@ jobs:
         run: pnpm build:firefox
 
       - name: Cache Firefox Nightly APK
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules/.cache/firefox-nightly
           key: fenix-nightly-${{ runner.os }}-x86_64-${{ github.run_id }}
@@ -132,7 +132,7 @@ jobs:
 
       - name: Upload failure screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-e2e-screenshots
           path: tests/e2e/screenshots/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,15 +10,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.PUSH_TOKEN }}
 
@@ -62,13 +62,13 @@ jobs:
     if: always() && (needs.bump-version.result == 'success' || needs.bump-version.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "pnpm"
@@ -105,13 +105,13 @@ jobs:
       EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
       EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "pnpm"

--- a/tests/e2e/step-definitions/gallery.steps.ts
+++ b/tests/e2e/step-definitions/gallery.steps.ts
@@ -8,6 +8,21 @@ const getElementCount = async (selector: string): Promise<number> => {
   return elements.length;
 };
 
+const waitForCount = async (getCount: () => Promise<number>, expected: number, label: string): Promise<number> => {
+  let actual = await getCount();
+  await browser.waitUntil(
+    async () => {
+      actual = await getCount();
+      return actual === expected;
+    },
+    {
+      timeout: 10000,
+      timeoutMsg: `Expected ${expected} ${label} but found ${actual}`,
+    },
+  );
+  return actual;
+};
+
 const scrollToLoadAllImages = async (): Promise<void> => {
   const footer = await $('footer');
   await footer.waitForExist({ timeout: 5000 });
@@ -51,13 +66,21 @@ When(
 
 Then('I should see {string} images loaded', async (count: string) => {
   const expectedCount = parseInt(count, 10);
-  const actualCount = await getElementCount(Selectors.GALLERY_IMAGE);
+  const actualCount = await waitForCount(
+    () => getElementCount(Selectors.GALLERY_IMAGE),
+    expectedCount,
+    'gallery images',
+  );
   await expect(actualCount).toBe(expectedCount);
 });
 
 Then('I should see {string} mask overlays', async (count: string) => {
   const expectedCount = parseInt(count, 10);
-  const segmentCount = await getElementCount(Selectors.SEGMENT_OVERLAY);
-  const bboxCount = await getElementCount(Selectors.BBOX_OVERLAY);
-  expect(segmentCount + bboxCount).toBe(expectedCount);
+  const getMaskCount = async (): Promise<number> => {
+    const segmentCount = await getElementCount(Selectors.SEGMENT_OVERLAY);
+    const bboxCount = await getElementCount(Selectors.BBOX_OVERLAY);
+    return segmentCount + bboxCount;
+  };
+  const actualCount = await waitForCount(getMaskCount, expectedCount, 'mask overlays');
+  expect(actualCount).toBe(expectedCount);
 });


### PR DESCRIPTION
## Summary

Bumps all GitHub Actions across the CI workflows to their latest major versions:

- `actions/checkout` v4 → v7
- `actions/setup-node` v4 → v6
- `actions/upload-artifact` v4 → v7
- `actions/cache` v4 → v5
- `pnpm/action-setup` v4 → v6

## Why these are drop-in

- pnpm version resolves from the `packageManager` field (no `version` input), so `pnpm/action-setup` needs no config change.
- `node-version` is pinned, so `setup-node` bumps don't change the runtime.

## Files changed

- `.github/workflows/e2e.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/publish.yml`

## Test plan

- [x] CI workflows (lint + e2e) run green on this PR