### PR TITLE
Cover prediction math with unit tests

### DIFF
--- a/entrypoints/background/modelUtils/corrections.test.ts
+++ b/entrypoints/background/modelUtils/corrections.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { edgeBoundingBoxCorrection } from '@/entrypoints/background/modelUtils/corrections';
+
+import type { IElementPrediction } from '@/utils/types';
+
+function prediction(box: { x: number; y: number; width: number; height: number }): IElementPrediction {
+  return {
+    classId: 0,
+    className: 'person',
+    probability: 0.9,
+    boundingBox: box,
+    masks: { width: 0, height: 0, startValue: 0, runs: [] },
+  };
+}
+
+function correctOne(
+  box: { x: number; y: number; width: number; height: number },
+  imageWidth: number,
+  imageHeight: number,
+  options?: { edgeThreshold?: number },
+) {
+  return edgeBoundingBoxCorrection([prediction(box)], imageWidth, imageHeight, options)[0]?.boundingBox;
+}
+
+describe('edgeBoundingBoxCorrection', () => {
+  it('snaps a near-full box out to every edge (default 10% threshold)', () => {
+    // Image 1000x1000 -> edge band = 100px. All four sides fall inside the band.
+    const result = correctOne({ x: 50, y: 50, width: 900, height: 900 }, 1000, 1000);
+    expect(result).toEqual({ x: 0, y: 0, width: 1000, height: 1000 });
+  });
+
+  it('leaves a centered box untouched', () => {
+    const box = { x: 400, y: 400, width: 200, height: 200 };
+    expect(correctOne(box, 1000, 1000)).toEqual(box);
+  });
+
+  it('snaps the top-left corner when x and y sit exactly on the threshold', () => {
+    // x = y = 100 = edge band, and `<=` snaps it to 0, which grows width/height.
+    const result = correctOne({ x: 100, y: 100, width: 200, height: 200 }, 1000, 1000);
+    expect(result).toEqual({ x: 0, y: 0, width: 300, height: 300 });
+  });
+
+  it('snaps the right edge when it sits exactly on the far boundary', () => {
+    // right = 900 = imageWidth - edgeBand, and `>=` snaps it out to imageWidth.
+    const result = correctOne({ x: 500, y: 500, width: 400, height: 100 }, 1000, 1000);
+    expect(result).toEqual({ x: 500, y: 500, width: 500, height: 100 });
+  });
+
+  it('respects a custom edgeThreshold', () => {
+    // With a 2% band (20px) a box starting at x=25 is no longer in the edge zone.
+    const box = { x: 25, y: 25, width: 200, height: 200 };
+    expect(correctOne(box, 1000, 1000, { edgeThreshold: 0.02 })).toEqual(box);
+    // ...whereas the default 10% band snaps it to the origin.
+    expect(correctOne(box, 1000, 1000)).toEqual({ x: 0, y: 0, width: 225, height: 225 });
+  });
+
+  it('with a zero threshold only snaps boxes already touching an edge', () => {
+    const interior = { x: 10, y: 10, width: 980, height: 980 };
+    expect(correctOne(interior, 1000, 1000, { edgeThreshold: 0 })).toEqual(interior);
+
+    const touching = { x: 0, y: 0, width: 1000, height: 1000 };
+    expect(correctOne(touching, 1000, 1000, { edgeThreshold: 0 })).toEqual(touching);
+  });
+
+  it('uses separate horizontal and vertical bands for non-square images', () => {
+    // 2000x500 -> bands of 200px (x) and 50px (y). Only the top edge (y=40) is within its band.
+    const result = correctOne({ x: 300, y: 40, width: 400, height: 200 }, 2000, 500);
+    expect(result).toEqual({ x: 300, y: 0, width: 400, height: 240 });
+  });
+
+  it('corrects every prediction and preserves their other fields and order', () => {
+    const predictions: IElementPrediction[] = [
+      { ...prediction({ x: 10, y: 10, width: 200, height: 200 }), className: 'a', classId: 1, probability: 0.7 },
+      { ...prediction({ x: 400, y: 400, width: 100, height: 100 }), className: 'b', classId: 2, probability: 0.8 },
+    ];
+
+    const corrected = edgeBoundingBoxCorrection(predictions, 1000, 1000);
+
+    expect(corrected).toHaveLength(2);
+    expect(corrected[0]).toMatchObject({ className: 'a', classId: 1, probability: 0.7 });
+    expect(corrected[0]?.boundingBox).toEqual({ x: 0, y: 0, width: 210, height: 210 });
+    expect(corrected[1]).toMatchObject({ className: 'b', classId: 2, probability: 0.8 });
+    expect(corrected[1]?.boundingBox).toEqual({ x: 400, y: 400, width: 100, height: 100 });
+  });
+
+  it('does not mutate the input predictions', () => {
+    const original = prediction({ x: 10, y: 10, width: 900, height: 900 });
+    const snapshot = structuredClone(original);
+
+    edgeBoundingBoxCorrection([original], 1000, 1000);
+
+    expect(original).toEqual(snapshot);
+  });
+});

--- a/entrypoints/background/modelUtils/corrections.ts
+++ b/entrypoints/background/modelUtils/corrections.ts
@@ -1,7 +1,7 @@
 import { type IElementPrediction } from '@/utils/types';
 
 export interface EdgeCorrectionOptions {
-  edgeThreshold?: number; // Percentage of image size to consider as edge (default: 0.02 = 2%)
+  edgeThreshold?: number; // Percentage of image size to consider as edge (default: 0.1 = 10%)
 }
 
 /**

--- a/entrypoints/background/modelUtils/maskTransform.test.ts
+++ b/entrypoints/background/modelUtils/maskTransform.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import { calculateLetterboxParams, calculateScaleFactors } from '@/entrypoints/background/modelUtils/maskTransform';
+
+describe('calculateScaleFactors', () => {
+  it('produces an identity transform for a square image at model size', () => {
+    expect(calculateScaleFactors(640, 640, 640, 640)).toEqual({
+      scaleX: 1,
+      scaleY: 1,
+      offsetX: 0,
+      offsetY: 0,
+    });
+  });
+
+  it('letterboxes vertically for a wide image (offset on Y only)', () => {
+    // scale = min(640/1280, 640/640) = 0.5 -> scaled 640x320, padded 160px top & bottom.
+    expect(calculateScaleFactors(1280, 640, 640, 640)).toEqual({
+      scaleX: 2,
+      scaleY: 2,
+      offsetX: 0,
+      offsetY: 160,
+    });
+  });
+
+  it('letterboxes horizontally for a tall image (offset on X only)', () => {
+    expect(calculateScaleFactors(640, 1280, 640, 640)).toEqual({
+      scaleX: 2,
+      scaleY: 2,
+      offsetX: 160,
+      offsetY: 0,
+    });
+  });
+
+  it('upscales a tiny image', () => {
+    // scale = min(640/2, 640/1) = 320 -> scaled 640x320, padded 160px top & bottom.
+    expect(calculateScaleFactors(2, 1, 640, 640)).toEqual({
+      scaleX: 2 / 640,
+      scaleY: 1 / 320,
+      offsetX: 0,
+      offsetY: 160,
+    });
+  });
+
+  it('handles an extreme wide aspect ratio with rounded scaled height', () => {
+    // scale = 0.64 -> scaledHeight = round(10 * 0.64) = round(6.4) = 6, offsetY = (640 - 6) / 2 = 317.
+    const result = calculateScaleFactors(1000, 10, 640, 640);
+    expect(result.offsetX).toBe(0);
+    expect(result.offsetY).toBe(317);
+    expect(result.scaleX).toBeCloseTo(1000 / 640, 10);
+    expect(result.scaleY).toBeCloseTo(10 / 6, 10);
+  });
+
+  it('keeps the letterbox offset as a float (matches Python YOLO reference)', () => {
+    // scaledHeight = round(640 * (640/641)) = round(639.0...) = 639 -> offsetY = (640 - 639) / 2 = 0.5.
+    const result = calculateScaleFactors(641, 640, 640, 640);
+    expect(result.offsetY).toBe(0.5);
+  });
+});
+
+describe('calculateLetterboxParams', () => {
+  it('crops nothing when the image already fills the model square', () => {
+    const result = calculateLetterboxParams(640, 640, 640, 640, 160, 160);
+    expect(result).toMatchObject({
+      scale: 1,
+      offsetX: 0,
+      offsetY: 0,
+      protoOffsetX: 0,
+      protoOffsetY: 0,
+      contentProtoWidth: 160,
+      contentProtoHeight: 160,
+    });
+  });
+
+  it('crops the vertical letterbox out of prototype space for a wide image', () => {
+    // offsetY = 160 input px -> 40 proto rows removed top & bottom (stride = 640/160 = 4).
+    const result = calculateLetterboxParams(1280, 640, 640, 640, 160, 160);
+    expect(result).toMatchObject({
+      scale: 0.5,
+      offsetX: 0,
+      offsetY: 160,
+      protoOffsetX: 0,
+      protoOffsetY: 40,
+      contentProtoWidth: 160,
+      contentProtoHeight: 80,
+    });
+  });
+
+  it('crops the horizontal letterbox out of prototype space for a tall image', () => {
+    const result = calculateLetterboxParams(640, 1280, 640, 640, 160, 160);
+    expect(result).toMatchObject({
+      scale: 0.5,
+      offsetX: 160,
+      offsetY: 0,
+      protoOffsetX: 40,
+      protoOffsetY: 0,
+      contentProtoWidth: 80,
+      contentProtoHeight: 160,
+    });
+  });
+
+  it('uses the full prototype grid when a tiny image is upscaled to fill the square', () => {
+    const result = calculateLetterboxParams(4, 4, 640, 640, 160, 160);
+    expect(result.contentProtoWidth).toBe(160);
+    expect(result.contentProtoHeight).toBe(160);
+  });
+});

--- a/entrypoints/background/modelUtils/scoreThreshold.test.ts
+++ b/entrypoints/background/modelUtils/scoreThreshold.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_SCORE_THRESHOLD,
+  MIN_SCORE_THRESHOLD,
+  strictnessToScoreThreshold,
+} from '@/entrypoints/background/modelUtils/scoreThreshold';
+
+describe('strictnessToScoreThreshold', () => {
+  it('maps minimum strictness to the most permissive (highest) threshold', () => {
+    expect(strictnessToScoreThreshold(0)).toBe(MAX_SCORE_THRESHOLD);
+  });
+
+  it('maps maximum strictness to the strictest (lowest) threshold', () => {
+    expect(strictnessToScoreThreshold(1)).toBe(MIN_SCORE_THRESHOLD);
+  });
+
+  it('passes mid-range strictness through as 1 - strictness', () => {
+    expect(strictnessToScoreThreshold(0.5)).toBeCloseTo(0.5, 10);
+    expect(strictnessToScoreThreshold(0.3)).toBeCloseTo(0.7, 10);
+  });
+
+  it('clamps to the upper bound just inside the low-strictness edge', () => {
+    // 1 - 0.05 = 0.95, clamped down to 0.9.
+    expect(strictnessToScoreThreshold(0.05)).toBe(MAX_SCORE_THRESHOLD);
+    // 1 - 0.1 = 0.9 sits exactly on the bound.
+    expect(strictnessToScoreThreshold(0.1)).toBe(MAX_SCORE_THRESHOLD);
+    // 1 - 0.11 = 0.89 stays just inside the bound.
+    expect(strictnessToScoreThreshold(0.11)).toBeCloseTo(0.89, 10);
+  });
+
+  it('clamps to the lower bound just inside the high-strictness edge', () => {
+    // 1 - 0.95 lands a hair above 0.05 in floating point, so it passes through unclamped.
+    expect(strictnessToScoreThreshold(0.95)).toBeCloseTo(0.05, 10);
+    // 1 - 0.99 = 0.01, clearly below the bound, so it clamps up to exactly 0.05.
+    expect(strictnessToScoreThreshold(0.99)).toBe(MIN_SCORE_THRESHOLD);
+    // 1 - 0.94 = 0.06 stays just inside the bound.
+    expect(strictnessToScoreThreshold(0.94)).toBeCloseTo(0.06, 10);
+  });
+
+  it('clamps out-of-range strictness instead of extrapolating', () => {
+    expect(strictnessToScoreThreshold(-1)).toBe(MAX_SCORE_THRESHOLD);
+    expect(strictnessToScoreThreshold(2)).toBe(MIN_SCORE_THRESHOLD);
+  });
+
+  it('propagates NaN strictness (settings are always valid numbers, so this only documents the math)', () => {
+    expect(strictnessToScoreThreshold(NaN)).toBeNaN();
+  });
+
+  it('keeps the bounds ordered and inside the probability range', () => {
+    expect(MIN_SCORE_THRESHOLD).toBeLessThan(MAX_SCORE_THRESHOLD);
+    expect(MIN_SCORE_THRESHOLD).toBeGreaterThan(0);
+    expect(MAX_SCORE_THRESHOLD).toBeLessThan(1);
+  });
+});

--- a/entrypoints/background/modelUtils/scoreThreshold.ts
+++ b/entrypoints/background/modelUtils/scoreThreshold.ts
@@ -1,0 +1,11 @@
+export const MIN_SCORE_THRESHOLD = 0.05;
+export const MAX_SCORE_THRESHOLD = 0.9;
+
+/**
+ * Map a user strictness in [0, 1] to a confidence threshold in [MIN_SCORE_THRESHOLD, MAX_SCORE_THRESHOLD].
+ * Higher strictness lowers the threshold so more detections clear it.
+ */
+export function strictnessToScoreThreshold(strictness: number): number {
+  const rawThreshold = 1 - strictness;
+  return Math.min(MAX_SCORE_THRESHOLD, Math.max(MIN_SCORE_THRESHOLD, rawThreshold));
+}

--- a/utils/inference/runtimes/onnx/postprocessors/instance.test.ts
+++ b/utils/inference/runtimes/onnx/postprocessors/instance.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+
+import { processInstanceSegmentation } from '@/utils/inference/runtimes/onnx/postprocessors/instance';
+
+import type { PostprocessContext, TypedResults } from '@/utils/inference/runtimes/onnx/postprocessors/types';
+import type { ModelMetadata } from '@/utils/types';
+
+const NUM_FEATURES = 38; // x1, y1, x2, y2, conf, cls + 32 mask coefficients
+const PROTO = 40; // prototype grid is 40x40 for a 160px model (stride 4)
+
+function makeConfig(overrides: Partial<ModelMetadata> = {}): ModelMetadata {
+  return {
+    names: { 0: 'person', 1: 'cat' },
+    imgsz: [160, 160],
+    normalize: null,
+    namesToCheck: ['person'],
+    outputShape: [PROTO, PROTO],
+    inputName: 'images',
+    outputNames: { detections: 'output0', masks: 'output1' },
+    stride: 32,
+    task: 'segment',
+    dynamicBatch: false,
+    ...overrides,
+  };
+}
+
+interface DetSpec {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  conf: number;
+  cls: number;
+  coeffs?: number[]; // mask coefficients, index 0..31
+}
+
+function det(spec: DetSpec): number[] {
+  const arr = new Array<number>(NUM_FEATURES).fill(0);
+  arr[0] = spec.x1;
+  arr[1] = spec.y1;
+  arr[2] = spec.x2;
+  arr[3] = spec.y2;
+  arr[4] = spec.conf;
+  arr[5] = spec.cls;
+  spec.coeffs?.forEach((v, c) => {
+    arr[6 + c] = v;
+  });
+  return arr;
+}
+
+function detectionsTensor(dets: number[][]): TypedResults[string] {
+  const data = new Float32Array(dets.length * NUM_FEATURES);
+  dets.forEach((d, i) => data.set(d, i * NUM_FEATURES));
+  return { data, dims: [1, dets.length, NUM_FEATURES] };
+}
+
+/** Prototype tensor whose channel 0 is filled with `value` and all other channels are 0. */
+function protoTensorChannel0(value: number): TypedResults[string] {
+  const data = new Float32Array(32 * PROTO * PROTO);
+  for (let i = 0; i < PROTO * PROTO; i++) data[i] = value;
+  return { data, dims: [1, 32, PROTO, PROTO] };
+}
+
+function run(ctx: Partial<PostprocessContext> & { results: TypedResults }) {
+  return processInstanceSegmentation({
+    config: makeConfig(),
+    scoreThreshold: 0.5,
+    originalWidth: 160,
+    originalHeight: 160,
+    ...ctx,
+  });
+}
+
+describe('processInstanceSegmentation — filtering', () => {
+  it('keeps only target-class detections above the score threshold', () => {
+    const results: TypedResults = {
+      output0: detectionsTensor([
+        det({ x1: 0, y1: 0, x2: 160, y2: 160, conf: 0.75, cls: 0, coeffs: [10] }), // person, kept
+        det({ x1: 0, y1: 0, x2: 160, y2: 160, conf: 0.75, cls: 1 }), // cat, not a target class
+        det({ x1: 0, y1: 0, x2: 160, y2: 160, conf: 0.25, cls: 0 }), // person, below threshold
+        det({ x1: 200, y1: 200, x2: 300, y2: 300, conf: 0.75, cls: 0 }), // person, outside content
+      ]),
+      output1: protoTensorChannel0(1),
+    };
+
+    const predictions = run({ results });
+
+    expect(predictions).toHaveLength(1);
+    expect(predictions[0]).toMatchObject({
+      classId: 0,
+      className: 'person',
+      probability: 0.75,
+      boundingBox: { x: 0, y: 0, width: 160, height: 160 },
+    });
+  });
+
+  it('keeps a detection whose confidence exactly equals the threshold', () => {
+    const results: TypedResults = {
+      output0: detectionsTensor([det({ x1: 0, y1: 0, x2: 160, y2: 160, conf: 0.5, cls: 0 })]),
+      output1: protoTensorChannel0(1),
+    };
+
+    expect(run({ results, scoreThreshold: 0.5 })).toHaveLength(1);
+  });
+
+  it('returns no predictions when the detections tensor is missing', () => {
+    expect(run({ results: {} })).toEqual([]);
+  });
+
+  it('returns no predictions for an empty detection list', () => {
+    expect(run({ results: { output0: detectionsTensor([]) } })).toEqual([]);
+  });
+});
+
+describe('processInstanceSegmentation — mask decoding', () => {
+  it('encodes an all-on mask when the coefficients drive sigmoid above 0.5', () => {
+    const results: TypedResults = {
+      output0: detectionsTensor([det({ x1: 0, y1: 0, x2: 160, y2: 160, conf: 0.75, cls: 0, coeffs: [10] })]),
+      output1: protoTensorChannel0(1), // sum = 10 -> sigmoid ~1 -> all pixels on
+    };
+
+    expect(run({ results })[0]?.masks).toEqual({
+      width: PROTO,
+      height: PROTO,
+      startValue: 1,
+      runs: [PROTO * PROTO],
+    });
+  });
+
+  it('encodes an all-off mask when the coefficients drive sigmoid below 0.5', () => {
+    const results: TypedResults = {
+      output0: detectionsTensor([det({ x1: 0, y1: 0, x2: 160, y2: 160, conf: 0.75, cls: 0, coeffs: [-10] })]),
+      output1: protoTensorChannel0(1), // sum = -10 -> sigmoid ~0 -> all pixels off
+    };
+
+    expect(run({ results })[0]?.masks).toEqual({
+      width: PROTO,
+      height: PROTO,
+      startValue: 0,
+      runs: [PROTO * PROTO],
+    });
+  });
+
+  it('emits an empty mask when no prototype tensor is present', () => {
+    const results: TypedResults = {
+      output0: detectionsTensor([det({ x1: 0, y1: 0, x2: 160, y2: 160, conf: 0.75, cls: 0, coeffs: [10] })]),
+    };
+
+    expect(run({ results })[0]?.masks).toEqual({ width: 0, height: 0, startValue: 0, runs: [] });
+  });
+});
+
+describe('processInstanceSegmentation — letterbox offset removal and clamping', () => {
+  it('removes the vertical letterbox and scales boxes back to original coordinates', () => {
+    // 320x160 image in a 160x160 model -> scale 0.5, 40px letterbox top & bottom, scale-back factor 2.
+    const results: TypedResults = {
+      output0: detectionsTensor([
+        // Box spanning the full content area maps back to the whole original image.
+        det({ x1: 0, y1: 40, x2: 160, y2: 120, conf: 0.75, cls: 0 }),
+        // Box reaching up into the top padding clamps to the content edge before scaling.
+        det({ x1: 40, y1: 20, x2: 120, y2: 100, conf: 0.75, cls: 0 }),
+      ]),
+    };
+
+    const predictions = processInstanceSegmentation({
+      config: makeConfig(),
+      scoreThreshold: 0.5,
+      originalWidth: 320,
+      originalHeight: 160,
+      results,
+    });
+
+    expect(predictions.map(p => p.boundingBox)).toEqual([
+      { x: 0, y: 0, width: 320, height: 160 },
+      { x: 80, y: 0, width: 160, height: 120 },
+    ]);
+  });
+});

--- a/utils/inference/runtimes/onnx/prediction.ts
+++ b/utils/inference/runtimes/onnx/prediction.ts
@@ -1,4 +1,5 @@
 import { edgeBoundingBoxCorrection } from '@/entrypoints/background/modelUtils/corrections';
+import { strictnessToScoreThreshold } from '@/entrypoints/background/modelUtils/scoreThreshold';
 import { createCacheMetadataFromMediaMetadata } from '@/utils/cacheUtils';
 import { getEffectiveHostname } from '@/utils/hostnameUtil';
 import { loadImageBitmap, preprocessImage } from '@/utils/inference/preprocessing';
@@ -28,8 +29,7 @@ interface PreparedImage {
 }
 
 function scoreThresholdFor(task: InferenceTask): number {
-  const rawThreshold = 1 - task.hostSettings.strictness;
-  return Math.min(0.9, Math.max(0.05, rawThreshold));
+  return strictnessToScoreThreshold(task.hostSettings.strictness);
 }
 
 interface ResolvedBitmap {

--- a/utils/rle.test.ts
+++ b/utils/rle.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+
+import { decodeMaskRLE, encodeMaskRLE, type IRLEMask } from '@/utils/rle';
+
+function flatten(mask: number[][]): number[] {
+  return mask.flat();
+}
+
+function randomMask(width: number, height: number, seed: number): Uint8Array {
+  // Deterministic pseudo-random fill so the round-trip test is reproducible.
+  const data = new Uint8Array(width * height);
+  let state = seed;
+  for (let i = 0; i < data.length; i++) {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    data[i] = (state >> 16) & 1;
+  }
+  return data;
+}
+
+describe('encodeMaskRLE', () => {
+  it('encodes a fully-zero mask as a single run starting at 0', () => {
+    const data = new Uint8Array(4 * 3); // all zeros
+    expect(encodeMaskRLE(data, 4, 3)).toEqual<IRLEMask>({
+      width: 4,
+      height: 3,
+      startValue: 0,
+      runs: [12],
+    });
+  });
+
+  it('encodes a fully-one mask as a single run starting at 1', () => {
+    const data = new Uint8Array(4 * 3).fill(1);
+    expect(encodeMaskRLE(data, 4, 3)).toEqual<IRLEMask>({
+      width: 4,
+      height: 3,
+      startValue: 1,
+      runs: [12],
+    });
+  });
+
+  it('alternates runs and always pushes the final run', () => {
+    // 0 0 1 1 1 0 -> runs [2, 3, 1] starting at 0
+    const data = Uint8Array.from([0, 0, 1, 1, 1, 0]);
+    expect(encodeMaskRLE(data, 6, 1)).toEqual<IRLEMask>({
+      width: 6,
+      height: 1,
+      startValue: 0,
+      runs: [2, 3, 1],
+    });
+  });
+
+  it('treats any non-zero byte as 1', () => {
+    const data = Uint8Array.from([5, 0, 200]);
+    expect(encodeMaskRLE(data, 3, 1)).toEqual<IRLEMask>({
+      width: 3,
+      height: 1,
+      startValue: 1,
+      runs: [1, 1, 1],
+    });
+  });
+
+  it('encodes a single-pixel mask', () => {
+    expect(encodeMaskRLE(Uint8Array.from([1]), 1, 1)).toEqual<IRLEMask>({
+      width: 1,
+      height: 1,
+      startValue: 1,
+      runs: [1],
+    });
+  });
+
+  it('returns an empty mask when dimensions are zero', () => {
+    expect(encodeMaskRLE(new Uint8Array(0), 0, 0)).toEqual<IRLEMask>({
+      width: 0,
+      height: 0,
+      startValue: 0,
+      runs: [],
+    });
+  });
+
+  it('returns an empty mask when the buffer is smaller than width * height', () => {
+    expect(encodeMaskRLE(Uint8Array.from([1, 0]), 4, 4)).toEqual<IRLEMask>({
+      width: 0,
+      height: 0,
+      startValue: 0,
+      runs: [],
+    });
+  });
+
+  it('ignores trailing bytes beyond width * height', () => {
+    const data = Uint8Array.from([1, 1, 0, 0, 9, 9]); // only first 4 belong to a 2x2 mask
+    expect(encodeMaskRLE(data, 2, 2)).toEqual<IRLEMask>({
+      width: 2,
+      height: 2,
+      startValue: 1,
+      runs: [2, 2],
+    });
+  });
+});
+
+describe('decodeMaskRLE', () => {
+  it('decodes runs row by row into a 2D array', () => {
+    const rle: IRLEMask = { width: 3, height: 2, startValue: 0, runs: [2, 3, 1] };
+    expect(decodeMaskRLE(rle)).toEqual([
+      [0, 0, 1],
+      [1, 1, 0],
+    ]);
+  });
+
+  it('returns an empty array for zero width', () => {
+    expect(decodeMaskRLE({ width: 0, height: 2, startValue: 1, runs: [4] })).toEqual([]);
+  });
+
+  it('returns an empty array for zero height', () => {
+    expect(decodeMaskRLE({ width: 2, height: 0, startValue: 1, runs: [4] })).toEqual([]);
+  });
+
+  it('returns an empty array when there are no runs', () => {
+    expect(decodeMaskRLE({ width: 2, height: 2, startValue: 0, runs: [] })).toEqual([]);
+  });
+});
+
+describe('RLE round-trip', () => {
+  it('encode -> decode reproduces the original mask', () => {
+    const width = 16;
+    const height = 10;
+    const original = randomMask(width, height, 42);
+
+    const decoded = decodeMaskRLE(encodeMaskRLE(original, width, height));
+
+    expect(flatten(decoded)).toEqual(Array.from(original));
+  });
+
+  it('round-trips a single-pixel mask', () => {
+    const decoded = decodeMaskRLE(encodeMaskRLE(Uint8Array.from([1]), 1, 1));
+    expect(decoded).toEqual([[1]]);
+  });
+
+  it('round-trips a mask whose final run reaches the last pixel', () => {
+    // Ends on a 1-run so the "push the final run" path carries the last pixel.
+    const data = Uint8Array.from([0, 0, 0, 1]);
+    const decoded = decodeMaskRLE(encodeMaskRLE(data, 2, 2));
+    expect(flatten(decoded)).toEqual([0, 0, 0, 1]);
+  });
+
+  it('round-trips an all-zero and an all-one mask', () => {
+    const zeros = new Uint8Array(6 * 6);
+    const ones = new Uint8Array(6 * 6).fill(1);
+
+    expect(flatten(decodeMaskRLE(encodeMaskRLE(zeros, 6, 6)))).toEqual(Array.from(zeros));
+    expect(flatten(decodeMaskRLE(encodeMaskRLE(ones, 6, 6)))).toEqual(Array.from(ones));
+  });
+});


### PR DESCRIPTION
Closes #54.

## Summary
- Add unit coverage for prediction math helpers, mask transforms, score thresholds, ONNX instance postprocessing, and RLE utilities.
- Adjust helper exports/logic needed by the new tests.

## Impact
- Improves confidence around the GIF/image inference pipeline math and postprocessing behavior.

## Validation
- `pnpm exec vitest run entrypoints/background/modelUtils/corrections.test.ts entrypoints/background/modelUtils/maskTransform.test.ts entrypoints/background/modelUtils/scoreThreshold.test.ts utils/inference/runtimes/onnx/postprocessors/instance.test.ts utils/rle.test.ts`